### PR TITLE
add faucet as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-react": "^5.0.1",
     "eslint-plugin-standard": "^1.3.2",
+    "faucet": "0.0.1",
     "tape": "^4.5.1",
     "webpack": "^1.13.0"
   },
   "scripts": {
     "build": "./node_modules/webpack/bin/webpack.js",
     "dev": "nodemon -e js,pug --watch server server/index.js",
+    "faucet": "./node_modules/.bin/faucet",
     "start": "node server/index.js",
     "test": "node --harmony test.js | faucet",
     "watch": "npm run build -- -w"


### PR DESCRIPTION
# Tickets

_n/a_
## Overview

`npm test` was failing for me; *_I don't have it installed globally._

``` sh
› npm test

> react-tictactoe@1.0.0 test /Users/brianswisher/Code/react-tictactoe
> node --harmony test.js | faucet

sh: faucet: command not found
events.js:154
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at exports._errnoException (util.js:890:11)
    at WriteWrap.afterWrite (net.js:767:14)
npm ERR! Test failed.  See above for more details.
```
## Verification Steps

``` sh
curl -o- https://gist.githubusercontent.com/brianswisher/e011c6ff724071c27ed004b02daed677/raw/d52f67259fcf1377ae883059a659c2e6c168eb53/dev-dependency-faucet.sh | bash
```
1. ^copy & paste into terminal
2. ^let test complete
3. verify:

``` sh
> react-tictactoe@1.0.0 test /Users/brianswisher/Code/react-tictactoe
> node --harmony test.js | npm run faucet


> react-tictactoe@1.0.0 faucet /Users/brianswisher/Code/react-tictactoe
> faucet

✓ Tic Tac Toe recognizes winning conditions
✓ Tic Tac Toe recognizes non-winning conditions
✓ Tic Tac Toe recognizes state changes
✓ Tic Tac Toe players can draw game
✓ Tic Tac Toe recognizes a player 1 win
✓ Tic Tac Toe recognizes a player 2 win
# tests 30
# pass  30
✓ ok
```
